### PR TITLE
fix: RLS対応のため全APIルートをservice_role keyに切り替え

### DIFF
--- a/src/app/api/bentos/route.js
+++ b/src/app/api/bentos/route.js
@@ -3,8 +3,8 @@ import { NextResponse } from 'next/server';
 
 // Supabaseクライアントのインスタンス化
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
 );
 
 export async function GET(req) {

--- a/src/app/api/buy/[id]/route.js
+++ b/src/app/api/buy/[id]/route.js
@@ -3,8 +3,8 @@ import { NextResponse } from 'next/server';
 
 // Supabaseクライアントのインスタンス化
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
 );
 
 // GET メソッド - 弁当データを取得

--- a/src/app/api/search/route.js
+++ b/src/app/api/search/route.js
@@ -2,8 +2,8 @@ import { createClient } from '@supabase/supabase-js';
 
 // Supabaseクライアントのインスタンス化
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
 );
 
 export async function GET(req) {

--- a/src/app/api/users/bentos/route.js
+++ b/src/app/api/users/bentos/route.js
@@ -2,8 +2,8 @@ import { createClient } from '@supabase/supabase-js';
 import { NextResponse } from 'next/server';
 
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
 );
 
 export async function GET(req) {

--- a/src/app/api/users/edit/[id]/route.js
+++ b/src/app/api/users/edit/[id]/route.js
@@ -3,8 +3,8 @@ import { NextResponse } from 'next/server';
 
 // Supabaseクライアントのインスタンス化
 const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    process.env.SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
 );
 
 // 弁当データを取得

--- a/src/app/api/users/login/route.js
+++ b/src/app/api/users/login/route.js
@@ -4,8 +4,8 @@ import bcrypt from 'bcrypt';
 
 // Supabaseクライアントのインスタンス化
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
 );
 
 // **POST**: ログイン認証

--- a/src/app/api/users/route.js
+++ b/src/app/api/users/route.js
@@ -4,8 +4,8 @@ import { NextResponse } from 'next/server';
 
 // Supabaseクライアントを作成
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
 );
 
 export async function GET(req) {

--- a/src/app/api/users/search/route.js
+++ b/src/app/api/users/search/route.js
@@ -2,8 +2,8 @@ import { createClient } from '@supabase/supabase-js';
 
 // Supabaseクライアントのインスタンス化
 const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
 );
 
 export async function GET(req) {

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -2,6 +2,6 @@
 import { createClient } from "@supabase/supabase-js";
 
 export const supabaseClient = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY
 );


### PR DESCRIPTION
NEXT_PUBLIC_SUPABASE_ANON_KEYからSUPABASE_SERVICE_ROLE_KEYに変更。 DBへのアクセスはすべてサーバー側（API Route）経由のため
anon keyは不要。Bentos・Companies・UsersテーブルのRLS有効化に備える。